### PR TITLE
管理者登録後の遷移先をホーム画面（ログイン画面）にリダイレクト

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return "redirect:/";
 	}
 
 	/////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #1 
## やったこと
- 管理者登録後の遷移先をホーム画面（ログイン画面）へリダイレクトに修正

## できるようになること（ユーザ目線）
- 管理者登録後にログイン画面へリダイレクトする

## 動作確認
- 済み

## その他
