### PR TITLE
バリデーションの実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'eclipse'
 	id 'org.springframework.boot' version '3.1.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 }

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,6 +3,9 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -72,7 +75,10 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@PostMapping("/insert")
-	public String insert(InsertAdministratorForm form) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult rs, Model model) {
+		if(rs.hasErrors()){
+			return "administrator/insert";
+		}
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -1,5 +1,11 @@
 package com.example.form;
 
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 /**
  * 管理者情報登録時に使用するフォーム.
  * 
@@ -8,10 +14,16 @@ package com.example.form;
  */
 public class InsertAdministratorForm {
 	/** 名前 */
+	@NotBlank
+	@Length(min = 2, max = 20)
 	private String name;
 	/** メールアドレス */
+	@NotBlank
+	@Email(message = "Email形式で入力してください")
 	private String mailAddress;
 	/** パスワード */
+	@NotBlank
+	@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "パスワードは英数字で記載してください")
 	private String password;
 
 	public String getName() {


### PR DESCRIPTION
Closes #2 
## やったこと
- バリデーションの実装
 * 名前... 空チェック、2~20文字チェック
 * メールアドレス... 空チェック、アドレス形式チェック
 * パスワード... 空チェック、英数字パターンチェック

## できるようになること（ユーザ目線）
- 上記バリデーションに引っかかる入力値で登録しようとすると登録画面に戻り、バリデーションメッセージが表示される
- 名前、メールアドレスはバリデーションエラーになっても入力値が保持されたままである

## 動作確認
- 済み

## その他

