### PR TITLE
SQLエラーハンドリング

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -82,7 +82,13 @@ public class AdministratorController {
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
-		administratorService.insert(administrator);
+		try{
+			administratorService.insert(administrator);
+		} catch(Exception e){
+			System.err.println("SQLのエラーが発生しました");
+			System.out.println(e.getMessage());
+			return "administrator/insert";
+		}
 		return "redirect:/";
 	}
 


### PR DESCRIPTION
Closes #3  
## やったこと
- Emailの重複チェックでエラーになった場合、登録せずに管理者登録画面にリダイレクトする

## できるようになること（ユーザ目線）
- 同じメールアドレスが存在していた場合、管理者を登録できない
※エラーメッセージなどの実装は特になし

## 動作確認
- すでに存在するメールアドレスで登録しようとすると、管理者登録画面にリダイレクトする
- DBに新しいデータがINSERTされていない

## その他
- エラーメッセージなどの実装は要検討
