### PR TITLE
確認用パスワード欄およびバリデーションエラーハンドリングの実装

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -77,6 +77,7 @@ public class AdministratorController {
 	@PostMapping("/insert")
 	public String insert(@Validated InsertAdministratorForm form, BindingResult rs, Model model) {
 		if(rs.hasErrors()){
+			System.out.println(rs.getAllErrors());
 			return "administrator/insert";
 		}
 		Administrator administrator = new Administrator();

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -2,6 +2,7 @@ package com.example.form;
 
 import org.hibernate.validator.constraints.Length;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -25,7 +26,17 @@ public class InsertAdministratorForm {
 	@NotBlank
 	@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "パスワードは英数字で記載してください")
 	private String password;
+	/** 確認用パスワード */
+	@NotBlank
+	private String passwordConf;
 
+	@AssertTrue(message = "パスワードと確認用パスワードが一致しません")
+	public boolean isPasswordValid(){
+		if(password == null || password.isEmpty()){
+			return false;
+		}
+		return password.equals(passwordConf);
+	}
 	public String getName() {
 		return name;
 	}
@@ -50,10 +61,17 @@ public class InsertAdministratorForm {
 		this.password = password;
 	}
 
+	public String getPasswordConf() {
+		return passwordConf;
+	}
+
+	public void setPasswordConf(String passwordConf) {
+		this.passwordConf = passwordConf;
+	}
+
 	@Override
 	public String toString() {
 		return "InsertAdministratorForm [name=" + name + ", mailAddress=" + mailAddress + ", password=" + password
-				+ "]";
+				+ ", passwordConf=" + passwordConf + "]";
 	}
-
 }

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -124,6 +124,30 @@
                     </div>
                   </div>
                 </div>
+                <!-- 確認用パスワード -->
+                <div class="form-group">
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <label for="passwordConf"> 確認用パスワード: </label>
+                      <label
+                        th:errors="*{passwordValid}"
+                        class="error-messages"
+                      >
+                        パスワードを入力してください
+                      </label>
+                      <input
+                        type="password"
+                        name="passwordConf"
+                        id="passwordConf"
+                        class="form-control"
+                        placeholder="passwordConf"
+                        th:field="*{passwordConf}"
+                        th:errorclass="error-input"
+                        value="xxxxxxxx"
+                      />
+                    </div>
+                  </div>
+                </div>
                 <!-- 登録ボタン -->
                 <div class="form-group">
                   <div class="row">


### PR DESCRIPTION
Closes #5 
## やったこと
- 確認用パスワード欄およびエラー表示欄の実装
- 確認用パスワードのバリデーションを実装(`@AssertTrueを使用`)

## できるようになること（ユーザ目線）
- 確認用パスワードとパスワードの入力値が異なる場合、バリデーションエラーで管理者登録画面に戻る
- バリデーションエラーメッセージが表示されている
- 入力値が同じ場合、新たに管理者を登録できる

## 動作確認
- 入力値が異なる場合、バリデーションエラーで管理者登録画面に戻り、DBにデータがINSERTされていない
- バリデーションエラーメッセージが表示されている
- 入力値が同じ場合、新たに管理者を登録できる

## その他

