### PR TITLE
入社年月日のフォーマットを修正

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -132,7 +132,7 @@
                   <tr>
                     <th nowrap>入社日</th>
                     <td>
-                      <span th:utext="${employee.hireDate}">2012/11/29</span>
+                      <span th:text="${#dates.format(employee.hireDate,'yyyy年MM月dd日')}">2012/11/29</span>
                     </td>
                   </tr>
                   <tr>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -107,20 +107,20 @@
               </tr>
             </thead>
             <tbody>
-              <tr th:each="employee : ${employeeList}">
+              <tr th:each="employee : ${employeeList}" th:object="${employee}">
                 <td>
                   <a
                     href="detail.html"
-                    th:href="@{'/employee/showDetail?id=' + ${employee.id}}"
+                    th:href="@{'/employee/showDetail?id=' + *{id}}"
                   >
                     <span th:text="${employee.name}">山田太郎</span>
                   </a>
                 </td>
                 <td>
-                  <span th:text="${employee.hireDate}">2016/12/1</span>
+                  <span th:text="*{#dates.format(hireDate,'yyyy年MM月dd日')}">2016/12/1</span>
                 </td>
                 <td>
-                  <span th:text="${employee.dependentsCount} + '人'">3人</span>
+                  <span th:text="*{dependentsCount} + '人'">3人</span>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Closes #8 
## やったこと
- 入社年月日のフォーマットを修正(`yyyy年MM月dd日`)

## できるようになること（ユーザ目線）
- 入社年月日が既定のフォーマットで出力される

## 動作確認
- 済み

## その他

