### PR TITLE
給料のフォーマットを3桁カンマ区切りに修正

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:text="${#numbers.formatInteger(employee.salary,3,'COMMA')} + 円">400000円</span>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
Closes #9 
## やったこと
- 給料のフォーマットを3桁カンマ区切りに修正

## できるようになること（ユーザ目線）
- 従業員詳細画面の給料欄が既定のフォーマットで出力される

## 動作確認
- 済み

## その他
