### PR TITLE
従業員一覧へ戻るパンくずリストの修正

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -84,7 +84,9 @@
 
       <!-- パンくずリスト -->
       <ol class="breadcrumb">
-        <li>従業員リスト</li>
+        <li>
+          <a href="list.html" th:href="@{/employee/showList}">従業員リスト</a>
+        </li>
         <li class="active">従業員詳細</li>
       </ol>
 


### PR DESCRIPTION
Closes #10 
## やったこと
- 従業員一覧へ戻るパンくずリストの修正

## できるようになること（ユーザ目線）
- 従業員詳細画面において、パンくずリストの`従業員リスト`のパンくずリストをクリックすると従業員一覧画面へ遷移する

## 動作確認
- 済み

## その他
