### PR TITLE
springsecurityの導入、パスワードのハッシュ化の実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation "org.springframework.boot:spring-boot-starter-security"
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.example.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+  @Bean
+  public PasswordEncoder passwordEncoder(){
+    return new BCryptPasswordEncoder();
+  }
+
+  // @SuppressWarnings("deprecation")
+  // @Bean
+  // public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  //   http.authorizeRequests((requests)->requests.requestMatchers("/login").permitAll().anyRequest().authenticated());
+  //   http.addFilterBefore(new AuthorizationFilter(null), UsernamePasswordAuthenticationFilter.class);
+	// 	return http.build();
+	// }
+}

--- a/src/main/java/com/example/repository/AdministratorRepository.java
+++ b/src/main/java/com/example/repository/AdministratorRepository.java
@@ -8,6 +8,7 @@ import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
 
 import com.example.domain.Administrator;
@@ -20,8 +21,8 @@ import com.example.domain.Administrator;
  */
 @Repository
 public class AdministratorRepository {
-
-
+	@Autowired
+	private PasswordEncoder passwordEncoder;
 	private static final String FIND_BY_MAILADDRESS_AND_PASSWARD_QUERY = """
 		select 
 			id,
@@ -85,6 +86,7 @@ public class AdministratorRepository {
 	 * @param administrator 管理者情報
 	 */
 	public void insert(Administrator administrator) {
+		administrator.setPassword(passwordEncoder.encode(administrator.getPassword()));
 		SqlParameterSource param = new BeanPropertySqlParameterSource(administrator);
 		String sql = "insert into administrators(name,mail_address,password)values(:name,:mailAddress,:password);";
 		template.update(sql, param);


### PR DESCRIPTION
Closes #11 
## やったこと
- springsecurityの導入
- `SecurityConfig`の中でPasswordEncoderメソッドを定義してDiコンテナに登録し、`AdministratorRepository#insert`内でパスワードをハッシュ化して登録するように実装

## できるようになること（ユーザ目線）
- 登録したパスワードがハッシュ化されてDBに保存される

## 動作確認
- アプリケーション起動後、自動生成されるパスワードと`user`でログイン後、管理者登録画面にて管理者情報を入力して登録ボタンを押下すると、DBにハッシュ化されたパスワードが保存される


## その他
- リダイレクト先や既存のログインフォームとの結合等は未実装のため、上記の自動生成パスワードと`user`でログインする必要あり
- `springsecurity`の設定により、リダイレクト先などが変わってしまっているため、要修正
