### PR TITLE
エラーページの編集

### DIFF
--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>/error</title>
+</head>
+<body>
+  <h2>カスタムエラーページ</h2>
+  <div th:if="${status} == '404'">
+    <h3>ページが見つかりません</h3>
+  </div>
+  <div th:if="${status} == '500'">
+    <h3>メンテナンス中</h3>
+  </div>
+
+  <div th:text="'timestamp: ' + ${timestamp}"></div>
+  <div th:text="'status: ' + ${status}"></div>
+  <div th:text="'error: ' + ${error}"></div>
+  <div th:text="'exception: ' + ${exception}"></div>
+  <div th:text="'message: ' + ${message}"></div>
+  <div th:text="'errors: ' + ${errors}"></div>
+  <!-- <div th:text="'trace: ' + ${trace}"></div> -->
+  <div th:text="'path: ' + ${path}"></div>
+  
+</body>
+</html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <h1>404エラー！！！（ページが見つかりません）</h1>
+</body>
+</html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <h1>500エラー！！！！（メンテナンス中）</h1>
+</body>
+</html>


### PR DESCRIPTION
Closes #14 
## やったこと
- 404,500エラーそれぞれに対応するカスタムエラーページを作成
- そのほかのエラーはカスタムエラーページ`error.html`にて表示するように修正

## できるようになること（ユーザ目線）
- ユーザーに分かりやすいエラー画面が表示される
- エラー時にはカスタムエラーページが表示される

## 動作確認
- 404,405,500エラーにて正しい挙動になることを確認

## その他

